### PR TITLE
docs: point people at the steady-mode beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,20 @@ _▶️ Holding the target angle on a whetstone — screen stays green. [Watch t
 
 ---
 
+## 🧪 Beta: steady mode — testers wanted
+
+If the live angle number jumps around while you sharpen, there's a beta that goes after exactly that.
+
+A sharpening stroke pushes the blade **sideways**, and the filter's guard against that was nearly blind to it: 0.18 g of sweep — the level the firmware already counts as a stroke — tilted its gravity reference **10.2°** while barely changing its magnitude, so it sailed through unrejected. The beta averages the gravity reference before it steers the angle (stroke acceleration cancels out over a cycle, gravity doesn't) and stops the displayed number and the colour from flip-flopping on sub-degree noise. Simulated, that's **2.3–4× steadier** depending on how fast you stroke.
+
+**You can switch it on and off on the device** — hold **B** on the TOLERANCE screen — so you can compare it against the old behaviour on the same knife, same stone, in the same session.
+
+[**🧪 Flash the beta →**](https://miamimoe.github.io/digital-sharpening-guide/beta.html) · it hasn't run on real hardware yet, which is the whole reason it's a beta. The [normal flasher](https://miamimoe.github.io/digital-sharpening-guide/) puts the stable release back whenever you want.
+
+**What would help most:** does the number actually sit still, and does green still arrive *fast enough*? Smoothing always trades response for calm — if green now feels late, that's the thing worth telling me. [Open an issue](https://github.com/miamimoe/digital-sharpening-guide/issues) either way.
+
+---
+
 ## ⚠️ Read this first
 
 This is a **hobby project at v0.2.1**, shared because people asked for it — not a precision instrument. It's a *coach to build muscle memory*, not a jig that holds the angle for you.

--- a/docs/index.html
+++ b/docs/index.html
@@ -97,6 +97,12 @@
       <p class="note" style="margin-top:16px;">When the dialog opens, pick the serial port (often labelled <em>CP2104</em> / <em>USB Serial</em> on a Plus/Plus2, or <em>USB JTAG/serial</em> on an S3) and choose <strong>Install</strong>.</p>
     </div>
 
+    <div class="panel" style="border-color:#f0a13a;">
+      <h2 style="color:#f0a13a;">🧪 Testers wanted: steady mode</h2>
+      <p style="margin-top:0">Does the angle number jump around while you sharpen? There's a beta that goes after exactly that — it stops stroke acceleration from dragging the reading, and stops the number and colour flip-flopping on sub-degree noise. You can toggle it on and off <strong>on the device</strong> to compare against the current behaviour in the same session.</p>
+      <p style="margin-bottom:0"><a href="beta.html"><strong>Flash the beta →</strong></a> <span class="note">It hasn't run on real hardware yet — that's what the beta is for. This flasher puts the stable release back whenever you want.</span></p>
+    </div>
+
     <script>
       // Point the installer at the manifest for the selected device.
       var deviceSelect = document.getElementById('device');


### PR DESCRIPTION
The beta shipped in #4 was live but `noindex` and linked from nowhere — nobody could find it, so it would have collected zero feedback, which was the whole point of shipping it.

## Changes

- **Flasher page** — a call-out panel under the install button.
- **README** — a "Beta: steady mode — testers wanted" section near the top.

Both lead with the symptom ("does the angle number jump around while you sharpen?") rather than the mechanism, state plainly that it hasn't run on real hardware, and point at the on-device A/B toggle so a tester can compare against current behaviour in one session rather than against memory.

Both also ask for the one piece of feedback that's hard to get any other way: **whether green still arrives fast enough.** Smoothing trades response for calm, and a lag regression is precisely the failure mode a simulation can't surface — so it needs to be asked for explicitly, not left for someone to volunteer.

## What is deliberately unchanged

- `beta.html` keeps its `noindex`. Findable from the project's own pages, not from a cold search landing with no context.
- Stable **v0.2.1** remains the default everywhere. The manifests, `docs/firmware/`, and `src/` are untouched — this is a docs-only diff, verified against `main`.

---
_Generated by [Claude Code](https://claude.ai/code/session_011ZE8rjpS2vZLfE3d7zd3Wh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added information about the beta Steady Mode firmware, which reduces angle and color fluctuations.
  * Added instructions for enabling Steady Mode by long-pressing **B** on the TOLERANCE screen.
  * Added links for beta firmware installation and returning to the stable release.
* **Documentation**
  * Added tester guidance and a request for feedback on hardware testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->